### PR TITLE
feat: Add contact management feature with validation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -81,3 +81,49 @@ button {
   font-style: normal;
   margin: 8px 0;
 }
+
+.contactForm .contactField {
+  text-align: left;
+  margin-bottom: 12px;
+}
+
+.contactForm label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.contactForm input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.contactForm input[aria-invalid="true"] {
+  border-color: #c00;
+}
+
+.contactFieldError {
+  display: block;
+  color: #c00;
+  font-size: 0.9em;
+  margin-top: 4px;
+}
+
+.contactActions {
+  margin-top: 16px;
+}
+
+.contactError {
+  color: #c00;
+  font-style: normal;
+  margin: 8px 0;
+}
+
+.contactSuccess {
+  color: #0a0;
+  font-style: normal;
+  margin: 8px 0;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,13 @@
 import "./App.css";
 import AddEducationPage from "./components/AddEducationPage";
+import ContactSection from "./components/ContactSection";
 import AddSkillPage from "./components/AddSkillPage";
 
 function App() {
   return (
     <div className="App">
       <h1>Resume Builder</h1>
+      <ContactSection />
       <div className="resumeSection">
         <h2>Experience</h2>
         <p>Experience Placeholder</p>
@@ -13,18 +15,6 @@ function App() {
         <br></br>
       </div>
       <AddEducationPage />
-      <div className="resumeSection">
-        <h2>Skills</h2>
-        <p>Skill Placeholder</p>
-        <button>Add Skill</button>
-        <br></br>
-      </div>
-      <div className="resumeSection">
-        <h2>Education</h2>
-        <p>Education Placeholder</p>
-        <button>Add Education</button>
-        <br></br>
-      </div>
       <AddSkillPage />
       <br></br>
       <button>Export</button>

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -1,0 +1,40 @@
+/**
+ * Contact API – add/update contact info via /resume/contact
+ * Configure base URL to point at your Flask backend when deployed.
+ */
+const BASE_URL = process.env.REACT_APP_API_URL || "";
+
+export async function getContact() {
+  const res = await fetch(`${BASE_URL}/resume/user`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("Failed to load contact");
+  return res.json();
+}
+
+export async function addContact(contact) {
+  const res = await fetch(`${BASE_URL}/resume/user`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(contact),
+  });
+  if (!res.ok) throw new Error("Failed to add contact");
+  return res.json();
+}
+
+export async function updateContact(contact) {
+  const res = await fetch(`${BASE_URL}/resume/user`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(contact),
+  });
+  if (!res.ok) throw new Error("Failed to update contact");
+  return res.json();
+}

--- a/src/components/ContactSection.js
+++ b/src/components/ContactSection.js
@@ -1,0 +1,198 @@
+import { useState, useEffect } from "react";
+import { getContact, addContact, updateContact } from "../api/contact";
+import { validateContact } from "../utils/contactValidation";
+
+const initialForm = { name: "", phone: "", email: "" };
+
+function ContactSection() {
+  const [contact, setContact] = useState(null);
+  const [form, setForm] = useState(initialForm);
+  const [errors, setErrors] = useState({});
+  const [isEditing, setIsEditing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [apiError, setApiError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getContact()
+      .then((data) => {
+        if (!cancelled && data && (data.name || data.phone || data.email)) {
+          setContact(data);
+          setForm({
+            name: data.name || "",
+            phone: data.phone || "",
+            email: data.email || "",
+          });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setContact(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+    if (errors[name]) setErrors((prev) => ({ ...prev, [name]: null }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const validation = validateContact(form);
+    if (validation) {
+      setErrors(validation);
+      return;
+    }
+    setErrors({});
+    setApiError(null);
+    setLoading(true);
+    const payload = {
+      name: form.name.trim(),
+      phone: form.phone.trim(),
+      email: form.email.trim(),
+    };
+    const promise = contact ? updateContact(payload) : addContact(payload);
+    promise
+      .then((data) => {
+        setContact(data || payload);
+        setForm(data || payload);
+        setIsEditing(false);
+      })
+      .catch((err) => setApiError(err.message || "Request failed"))
+      .finally(() => setLoading(false));
+  };
+
+  const startEdit = () => {
+    setForm(
+      contact
+        ? {
+            name: contact.name || "",
+            phone: contact.phone || "",
+            email: contact.email || "",
+          }
+        : initialForm
+    );
+    setErrors({});
+    setIsEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setForm(contact ? { ...contact } : initialForm);
+    setErrors({});
+    setIsEditing(false);
+  };
+
+  const showForm = isEditing || !contact;
+
+  return (
+    <div className="resumeSection">
+      <h2>Contact</h2>
+      {apiError && (
+        <p className="contactError" role="alert">
+          {apiError}
+        </p>
+      )}
+      {loading && <p className="contactLoading">Loading…</p>}
+      {showForm ? (
+        <form onSubmit={handleSubmit} className="contactForm" noValidate>
+          <div className="contactField">
+            <label htmlFor="contact-name">Name</label>
+            <input
+              id="contact-name"
+              name="name"
+              type="text"
+              value={form.name}
+              onChange={handleChange}
+              placeholder="Full name"
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? "contact-name-error" : undefined}
+            />
+            {errors.name && (
+              <span id="contact-name-error" className="contactFieldError">
+                {errors.name}
+              </span>
+            )}
+          </div>
+          <div className="contactField">
+            <label htmlFor="contact-phone">
+              Phone (international with country code)
+            </label>
+            <input
+              id="contact-phone"
+              name="phone"
+              type="tel"
+              value={form.phone}
+              onChange={handleChange}
+              placeholder="e.g. +1 555 123 4567"
+              aria-invalid={!!errors.phone}
+              aria-describedby={
+                errors.phone ? "contact-phone-error" : undefined
+              }
+            />
+            {errors.phone && (
+              <span id="contact-phone-error" className="contactFieldError">
+                {errors.phone}
+              </span>
+            )}
+          </div>
+          <div className="contactField">
+            <label htmlFor="contact-email">Email</label>
+            <input
+              id="contact-email"
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              placeholder="you@example.com"
+              aria-invalid={!!errors.email}
+              aria-describedby={
+                errors.email ? "contact-email-error" : undefined
+              }
+            />
+            {errors.email && (
+              <span id="contact-email-error" className="contactFieldError">
+                {errors.email}
+              </span>
+            )}
+          </div>
+          <div className="contactActions">
+            <button type="submit" disabled={loading}>
+              {contact ? "Update contact" : "Add contact"}
+            </button>
+            {contact && (
+              <button type="button" onClick={cancelEdit} disabled={loading}>
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+      ) : (
+        <>
+          <div className="contactDisplay">
+            <p>
+              <strong>Name:</strong> {contact.name}
+            </p>
+            <p>
+              <strong>Phone:</strong> {contact.phone}
+            </p>
+            <p>
+              <strong>Email:</strong> {contact.email}
+            </p>
+          </div>
+          <button type="button" onClick={startEdit}>
+            Update contact
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ContactSection;

--- a/src/utils/contactValidation.js
+++ b/src/utils/contactValidation.js
@@ -13,7 +13,9 @@ export const validateContact = (contact) => {
 
   if (!contact.phone || contact.phone.trim() === "") {
     errors.phone = "Phone is required";
-  } else if (!/^\d{10}$|^\d{3}-\d{3}-\d{4}$/.test(contact.phone.replace(/\D/g, ""))) {
+  } else if (
+    !/^\d{10}$|^\d{3}-\d{3}-\d{4}$/.test(contact.phone.replace(/\D/g, ""))
+  ) {
     errors.phone = "Phone must be a valid 10-digit number";
   }
 

--- a/src/utils/contactValidation.js
+++ b/src/utils/contactValidation.js
@@ -1,0 +1,21 @@
+export const validateContact = (contact) => {
+  const errors = {};
+
+  if (!contact.name || contact.name.trim() === "") {
+    errors.name = "Name is required";
+  }
+
+  if (!contact.email || contact.email.trim() === "") {
+    errors.email = "Email is required";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contact.email)) {
+    errors.email = "Email is invalid";
+  }
+
+  if (!contact.phone || contact.phone.trim() === "") {
+    errors.phone = "Phone is required";
+  } else if (!/^\d{10}$|^\d{3}-\d{3}-\d{4}$/.test(contact.phone.replace(/\D/g, ""))) {
+    errors.phone = "Phone must be a valid 10-digit number";
+  }
+
+  return errors;
+};


### PR DESCRIPTION
Fix issue https://github.com/MLH-Fellowship/orientation-project-JS-26.SPR.A/issues/1

Add a page that allows users to add their name, phone number, and email address


When this information is submitted, a POST request should be made to /resume/experience on the server in the following format:

```
{
  "name": "Jane Doe",
  "phone": "+1 555 123 4567",
  "email": "jane@example.com"
}
```
<img width="1903" height="898" alt="Screenshot 2026-02-01 152817" src="https://github.com/user-attachments/assets/9bc46b31-8e63-4c40-8405-695888d5a0c9" />
